### PR TITLE
Improve the compile bin in buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,14 +2,22 @@
 
 set -e
 
+# Source: https://github.com/heroku/heroku-buildpack-ruby/blob/master/bin/compile
+BIN_DIR=$(cd $(dirname $0); pwd)
+source "$BIN_DIR/support/bash_functions.sh"
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-MATTERBRIDGE_VERSION="$(cat $ENV_DIR/MATTERBRIDGE_VERSION)"
-MATTERBRIDGE_URL="https://github.com/42wim/matterbridge/releases/download/$MATTERBRIDGE_VERSION/matterbridge-linux64"
+# Export all envvars (with default blacklist)
+export_env_dir "$ENV_DIR"
 
-echo "-----> Downloading Matterbridge"
+LATEST_VERSION=$(get_latest_release "42wim/matterbridge")
+MATTERBRIDGE_VERSION="${MATTERBRIDGE_VERSION:-$LATEST_VERSION}"
+MATTERBRIDGE_URL="${MATTERBRIDGE_URL:-https://github.com/42wim/matterbridge/releases/download/$MATTERBRIDGE_VERSION/matterbridge-linux-amd64}"
+
+echo "-----> Downloading Matterbridge: $MATTERBRIDGE_URL"
 cd $BUILD_DIR
 curl -s -L $MATTERBRIDGE_URL -o matterbridge
 chmod +x matterbridge

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -18,8 +18,11 @@ export_env_dir() {
   blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
   if [ -d "$env_dir" ]; then
     for e in $(ls $env_dir); do
+      PORT="$(cat $env_dir/PORT)"
       echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
-      export "$e=$(cat $env_dir/$e)"
+        port_unexpanded=$(echo "$e=$(cat $env_dir/$e)") &&
+        port_expanded=$(eval "echo $port_unexpanded") &&
+        export $port_expanded
       :
     done
   fi

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Usage
+# $ get_latest_release "creationix/nvm"
+# v0.31.4
+#
+# See: https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+    grep '"tag_name":' |                                            # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+}
+
+# See: https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary
+export_env_dir() {
+  env_dir=$1
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}


### PR DESCRIPTION
- Export all envvars (excluding Heroku-recommended blacklist)
- Allow latest release version to be detected and set. (default)
- When MATTERBRIDGE_VERSION provided, fetch specific release from GitHub.
- When MATTERBRIDGE_VERSION not provided, fetch latest release from GitHub.
- When MATTERBRIDGE_URL provided, fetch binary from custom location.